### PR TITLE
Add Github action to build Docker image on main and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Create and publish the Ground Station Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['main', 'action-to-build-docker']
+    branches: ['main']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,9 @@ name: Create and publish the Ground Station Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['main', 'action-to-build-docker']
+    branches: ['main']
+  pull_request:
+    branches: ['main']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -47,7 +49,6 @@ jobs:
         with:
           context: ground-server
           push: true
-          visibility: public
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Create and publish the Ground Station Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'action-to-build-docker']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -47,6 +47,7 @@ jobs:
         with:
           context: ground-server
           push: true
+          visibility: public
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 #
 name: Create and publish the Ground Station Docker image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
+# Configures this workflow to run every time a change is pushed to the branch called `main` or a pull request to `main` is created
 on:
   push:
     branches: ['main']
@@ -51,7 +51,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
@@ -59,5 +59,5 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-      
+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ground-server
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+#
+name: Create and publish the Ground Station Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['main', 'action-to-build-docker']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: ground-server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ground Support Equipment Software for the Cornell Rocketry Team including fill s
 First, install Docker for your specific computer. Then, to start the ground server run:
 ```shell
 docker pull ghcr.io/cornellrocketryteam/ground-software
-docker run -it -d -p 80:80 zachgarcia42/ground-server-image
+docker run -it -d -p 80:80 ghcr.io/cornellrocketryteam/ground-software
 ```
 
 ## Fix and Format Bazel files

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Ground Support Equipment Software for the Cornell Rocketry Team including fill s
 
 First, install Docker for your specific computer. Then, to start the ground server run:
 ```shell
-docker pull ghcr.io/cornellrocketryteam/ground-software
-docker run -it -d -p 80:80 ghcr.io/cornellrocketryteam/ground-software
+docker pull ghcr.io/cornellrocketryteam/ground-server
+docker run -it -d -p 80:80 ghcr.io/cornellrocketryteam/ground-server
 ```
 
 ## Fix and Format Bazel files

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 Ground Support Equipment Software for the Cornell Rocketry Team including fill station and ground server
 
 ## Ground Server
-To start the ground server, run
-```sudo snap install docker```
-```docker pull zachgarcia42/ground-server-image```
-```docker run -it -d -p 80:80 zachgarcia42/ground-server-image```
+
+First, install Docker for your specific computer. Then, to start the ground server run:
+```shell
+docker pull ghcr.io/cornellrocketryteam/ground-software
+docker run -it -d -p 80:80 zachgarcia42/ground-server-image
+```
 
 ## Fix and Format Bazel files
 Buildifier will fix a lot and format all bazel files by running


### PR DESCRIPTION
Add Github action to build Docker image on main and pull requests. It publishes these images to the Github Container Registry (which is linked to this repo) so that they can be pulled by anyone. Additionally, images of specific branches that have PRs can be pulled and tested. 

This resolves #15 