### PR TITLE
Fix Ground Software build in Github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-#
 name: Create and publish the Ground Station Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `main` or a pull request to `main` is created
@@ -11,7 +10,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ground-server
+  IMAGE_NAME: ${{ github.repository_owner }}/ground-server
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -40,6 +39,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
This PR fixes the Docker build Github action. Zach was right... the image name needed to be prefixed with "cornellrocketryteam" to be a valid image name. I fixed that, and also tag the images that are made on the main branch as "latest" so they are automatically installed when `docker pull` is ran.