### PR TITLE
Add production docker compose config

### DIFF
--- a/compose_prod.yml
+++ b/compose_prod.yml
@@ -1,0 +1,54 @@
+services:
+  webserver:
+    image: ghcr.io/cornellrocketryteam/ground-server:latest
+    networks:
+      - ground-network
+    ports:
+      - 80:80
+    depends_on:
+      - influxdb
+  telemetry-proxy:
+    image: ghcr.io/cornellrocketryteam/telemetry-proxy:latest
+    depends_on:
+      - influxdb
+      - webserver
+    networks:
+      - ground-network
+    env_file:
+      - ./.env.proxy
+  influxdb:
+    image: influxdb:latest
+    networks:
+      - ground-network
+    ports:
+      - 8086:8086
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME_FILE: /run/secrets/influxdb-admin-username
+      DOCKER_INFLUXDB_INIT_PASSWORD_FILE: /run/secrets/influxdb-admin-password 
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE: /run/secrets/influxdb-admin-token
+      DOCKER_INFLUXDB_INIT_ORG: crt
+      DOCKER_INFLUXDB_INIT_BUCKET: telemetry
+    secrets:
+      - influxdb-admin-username
+      - influxdb-admin-password
+      - influxdb-admin-token
+    volumes:
+      - type: volume
+        source: influxdb-data
+        target: /var/lib/influxdb
+      - type: volume
+        source: influxdb-config
+        target: /etc/influxdb
+secrets:
+  influxdb-admin-username:
+    file: ./.env.influxdb-admin-username
+  influxdb-admin-password:
+    file: ./.env.influxdb-admin-password
+  influxdb-admin-token:
+    file: ./.env.influxdb-admin-token
+volumes:
+  influxdb-data:
+  influxdb-config:
+networks:
+  ground-network:

--- a/telemetry-proxy/telemetry_proxy.go
+++ b/telemetry-proxy/telemetry_proxy.go
@@ -17,14 +17,10 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
 )
 
-const (
-	address = "fill-station:50051" // Replace with your server address
-)
-
 func main() {
 	// Set up a connection to the influxdb instance.
 	token := os.Getenv("INFLUXDB_TOKEN")
-	influx_url := "http://influxdb:8086"
+	influx_url := "http://"+os.Getenv("INFLUXDB_HOSTNAME")+":8086"
 	influx_client := influxdb2.NewClient(influx_url, token)
 
 	org := "crt"
@@ -32,6 +28,7 @@ func main() {
 	writeAPI := influx_client.WriteAPIBlocking(org, bucket)
 
 	// Set up a connection to the grpc server
+	address := os.Getenv("FILL_HOSTNAME")+":50051" // Replace with your server address
 	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)


### PR DESCRIPTION
### TL;DR

Added a production Docker Compose configuration and updated the telemetry proxy to use environment variables for hostnames.

### What changed?

- Created a new `compose_prod.yml` file with Docker Compose configuration for production environment
- Added services for webserver, telemetry-proxy, and influxdb
- Configured secrets and volumes for influxdb
- Updated `telemetry_proxy.go` to use environment variables for InfluxDB and Fill Station hostnames

### How to test?

1. Set up the required environment variables in `.env.proxy`, `.env.influxdb-admin-username`, `.env.influxdb-admin-password`, and `.env.influxdb-admin-token`
2. Run `docker-compose -f compose_prod.yml up` to start the services
3. Verify that the webserver is accessible on port 80
4. Check that the telemetry proxy can connect to both InfluxDB and the Fill Station
5. Ensure data is being properly written to InfluxDB

### Why make this change?

This change provides a production-ready Docker Compose configuration, making it easier to deploy and manage the ground station services. The use of environment variables for hostnames in the telemetry proxy increases flexibility and allows for easier configuration across different environments.

Fixes #88