### PR TITLE
Display live telemetry on web server

### DIFF
--- a/ground-server/src/components/telemetry-adder.tsx
+++ b/ground-server/src/components/telemetry-adder.tsx
@@ -30,31 +30,31 @@ import { type Telemetry, type Widget } from "@/lib/definitions";
 
 const telemetry: Telemetry[] = [
   {
-    value: "velocity",
+    id: "velocity",
     label: "Velocity",
   },
   {
-    value: "altitude",
+    id: "altitude",
     label: "Altitude",
   },
   {
-    value: "rssi",
+    id: "rssi",
     label: "RSSI",
   },
   {
-    value: "longitude",
+    id: "longitude",
     label: "Longitude",
   },
   {
-    value: "latitude",
+    id: "latitude",
     label: "Latitude",
   },
   {
-    value: "temperature",
+    id: "temperature",
     label: "Temperature",
   },
   {
-    value: "pressure",
+    id: "pressure",
     label: "Pressure",
   },
 ];
@@ -115,7 +115,7 @@ function StatusList({
     setWidgets((widgets) => [
       ...widgets,
       {
-        children: <div>{t.label}</div>,
+        value: null,
         layout: {
           i: Date.now().toString(),
           x: 0,
@@ -125,6 +125,7 @@ function StatusList({
           minW: 3,
           minH: 2,
         },
+        telemetryType: t.label,
       },
     ]);
 
@@ -139,8 +140,8 @@ function StatusList({
         <CommandGroup>
           {telemetry.map((t) => (
             <CommandItem
-              key={t.value}
-              value={t.value}
+              key={t.id}
+              id={t.id}
               onSelect={() => addWidget(t)}
             >
               {t.label}

--- a/ground-server/src/lib/definitions.ts
+++ b/ground-server/src/lib/definitions.ts
@@ -1,12 +1,12 @@
-import { type ReactNode } from 'react'
 import { type Layout } from 'react-grid-layout'
 
 export type Telemetry = {
-    value: string;
+    id: string;
     label: string;
 };
 
 export type Widget = {
-    children: ReactNode
-    layout: Layout
-}
+    value: number | null;
+    layout: Layout;
+    telemetryType: string;
+};


### PR DESCRIPTION
### TL;DR
Fixes #89 and fixes #9
Implemented real-time telemetry updates via WebSocket connection and refactored widget data structure.

### What changed?

- Added WebSocket connection in the Home component to receive real-time telemetry updates
- Updated widget state to store and display telemetry values
- Refactored Telemetry and Widget type definitions
- Modified TelemetryAdder component to use new data structure
- Updated widget rendering to display telemetry type and value

### How to test?

1. Start the WebSocket server at `ws://localhost:8080/ws`
2. Run the ground server application
3. Add telemetry widgets to the dashboard
4. Send test messages through the WebSocket connection
5. Verify that widget values update in real-time
6. Check console logs for connection status and widget updates

### Why make this change?

This change enables real-time telemetry updates in the dashboard, providing a more dynamic and responsive user interface. The refactored data structure improves type safety and allows for easier management of telemetry data across components.