### PR TITLE
Update webserver URL to use env var

### DIFF
--- a/compose_prod.yml
+++ b/compose_prod.yml
@@ -7,6 +7,8 @@ services:
       - 80:80
     depends_on:
       - influxdb
+    env_file:
+      - ./.env.ground-server
   telemetry-proxy:
     image: ghcr.io/cornellrocketryteam/telemetry-proxy:latest
     depends_on:

--- a/ground-server/src/app/page.tsx
+++ b/ground-server/src/app/page.tsx
@@ -18,8 +18,10 @@ export default function Home() {
   const [widgets, setWidgets] = useState<Widget[]>([]);
   const [data, setData] = useState<Data>({ temp: 0 });
 
+  const websocketUrl = process.env.WEBSOCKET_URL || "ws://localhost:8080/ws";
+
   useEffect(() => {
-    const ws = new WebSocket("ws://localhost:8080/ws"); // Replace with your WebSocket server URL
+    const ws = new WebSocket(websocketUrl);
 
     ws.onopen = () => {
       console.log("WebSocket connection opened");


### PR DESCRIPTION
### TL;DR

Added environment file support for ground-server and made WebSocket URL configurable.

### What changed?

- Added an environment file (.env.ground-server) for the ground-server service in the Docker Compose configuration.
- Introduced a configurable WebSocket URL in the ground-server's page component.
- The WebSocket URL now uses an environment variable (WEBSOCKET_URL) with a fallback to "ws://localhost:8080/ws".

### How to test?

1. Create a .env.ground-server file in the project root with the desired environment variables.
2. Set the WEBSOCKET_URL environment variable to your WebSocket server URL.
3. Run the Docker Compose setup and verify that the ground-server connects to the specified WebSocket URL.
4. Test the application to ensure it functions correctly with the new WebSocket connection.

### Why make this change?

This change improves the flexibility and configurability of the ground-server:
- Using an environment file allows for easier management of environment-specific settings.
- Making the WebSocket URL configurable enables seamless deployment across different environments without code changes.
- The fallback URL ensures backward compatibility and ease of local development.