### PR TITLE
Make add telemetry channel button bigger

### DIFF
--- a/ground-server/src/components/telemetry-adder.tsx
+++ b/ground-server/src/components/telemetry-adder.tsx
@@ -41,8 +41,8 @@ export default function TelemetryAdder({
     return (
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button size="icon" className="px-2 py-2 h-15 w-15">
-            <PlusIcon className="h-6 w-6" />
+          <Button className="px-4 py-2 md:py-3 md:px-5 lg:py-5 lg:text-lg">
+            <PlusIcon className="h-4 w-4 xl:h-5 xl:w-5 mr-2" /> Add Channel
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[200px] p-0" align="end">
@@ -55,15 +55,15 @@ export default function TelemetryAdder({
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerTrigger asChild>
-        <Button size="icon" className="px-2 py-2 h-15 w-15">
-          <PlusIcon className="h-6 w-6" />
+        <Button className="px-4 py-2 md:py-3 md:px-5 lg:py-5 lg:text-lg">
+          <PlusIcon className="h-4 w-4 xl:h-5 xl:w-5 mr-2" /> Add Channel
         </Button>
       </DrawerTrigger>
       <DrawerContent>
         <DrawerHeader hidden>
           <DrawerTitle hidden>Add telemetry</DrawerTitle>
           <DrawerDescription hidden>
-            Select what telemetry datapoint to add to the dashboard
+            Select what telemetry channel to add to the dashboard
           </DrawerDescription>
         </DrawerHeader>
         <div className="border-t">


### PR DESCRIPTION
### TL;DR

Updated the "Add Channel" button design and improved drawer description.

### What changed?

- Modified the "Add Channel" button to include text alongside the plus icon
- Adjusted the icon size from 6x6 to 4x4
- Updated the drawer description to use "channel" instead of "datapoint"
- Removed the `size="icon"` attribute from the Button components

### How to test?

1. Open the telemetry dashboard
2. Locate the "Add Channel" button
3. Verify that the button now displays "Add Channel" text next to the plus icon
4. Click the button to open the drawer
5. Check that the drawer description now refers to "telemetry channel" instead of "datapoint"

### Why make this change?

This change improves the user interface by making the "Add Channel" functionality more explicit and easier to understand. The addition of text to the button enhances clarity, while the updated drawer description provides more accurate terminology. These modifications aim to enhance the overall user experience and reduce potential confusion when interacting with the telemetry dashboard.