### PR TITLE
Split up widget type into 3 state variables

### DIFF
--- a/ground-server/src/app/page.tsx
+++ b/ground-server/src/app/page.tsx
@@ -3,7 +3,7 @@
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { WidthProvider, Responsive, type Layout } from "react-grid-layout";
 
 import { WidgetHandle } from "@/components/dashboard/widget-handle";
@@ -11,101 +11,44 @@ import { DashboardWidget } from "@/components/dashboard/dashboard-widget";
 import { TelemetryAdder } from "@/components/dashboard/telemetry-adder";
 import { PresetSelector } from "@/components/dashboard/preset-selector";
 
-import { type Widget, type DataPoint } from "@/lib/definitions";
+import { type DataPoint, type TelemetryChannel } from "@/lib/definitions";
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 export default function Home() {
-  const [widgets, setWidgets] = useState<Widget[]>([]);
+  const [channels, setChannels] = useState<
+    {
+      id: string;
+      channel: TelemetryChannel;
+    }[]
+  >([]);
+  const [layouts, setLayouts] = useState<
+    {
+      id: string;
+      layout: Layout;
+    }[]
+  >([]);
+  const [data, setData] = useState<
+    {
+      id: string;
+      data: DataPoint[];
+    }[]
+  >([]);
   const wsRef = useRef<WebSocket | null>(null); // Store the WebSocket instance
 
   useEffect(() => {
-    const ws = new WebSocket("ws://localhost:8080/ws"); // Replace with your WebSocket server URL
+    wsRef.current = new WebSocket("ws://localhost:8080/ws"); // Replace with your WebSocket server URL
 
-    ws.onopen = () => {
+    wsRef.current.onopen = () => {
       console.log("WebSocket connection opened");
-      wsRef.current = ws; // Store the WebSocket instance
     };
 
-    ws.onmessage = (event) => {
-      const message = JSON.parse(event.data);
-
-      if (message.historical) {
-        // Historical data
-        console.log("Historical Message Received");
-
-        setWidgets((prevWidgets) =>
-          prevWidgets.map((widget) => {
-            if (widget.channel.dbField === message.field) {
-              console.log("Widget has matching field");
-              const widgetData: DataPoint[] = message.data.map(
-                (item: { timestamp: string; value: number }) => {
-                  return {
-                    timestamp: new Date(item.timestamp),
-                    value: item.value,
-                  };
-                }
-              );
-              return { ...widget, data: widgetData };
-            } else {
-              console.log(
-                `Fields did not match ${widget.channel.dbField} and ${message.field}`
-              );
-              return widget;
-            }
-          })
-        );
-      } else {
-        // Live data
-
-        setWidgets((prevWidgets) =>
-          prevWidgets.map((widget) => {
-            const field = widget.channel.jsonField;
-            let newValue = null;
-            if (field in message) {
-              console.log("%s in message.", field);
-              newValue = message[field];
-            } else if (field in message.rockTelem) {
-              console.log("%s in message.rockTelem.", field);
-              newValue = message.rockTelem[field];
-            } else if (field in message.rockTelem.accelTelem) {
-              console.log("%s in message.rockTelem.accelTelem.", field);
-              newValue = message.rockTelem.accelTelem[field];
-            } else if (field in message.rockTelem.events) {
-              newValue = message.rockTelem.events[field];
-            } else if (field in message.rockTelem.gpsTelem) {
-              newValue = message.rockTelem.gpsTelem[field];
-            } else if (field in message.rockTelem.imuTelem) {
-              newValue = message.rockTelem.imuTelem[field];
-            } else if (field in message.rockTelem.metadata) {
-              newValue = message.rockTelem.metadata[field];
-            } else {
-              console.log("%s not in message.", field);
-            }
-
-            if (newValue) {
-              console.log(widget);
-              return {
-                ...widget,
-                data: [
-                  ...widget.data,
-                  { timestamp: new Date(), value: newValue },
-                ],
-              };
-            }
-
-            return widget;
-          })
-        );
-      }
-    };
-
-    ws.onclose = () => {
+    wsRef.current.onclose = () => {
       console.log("WebSocket connection closed");
       wsRef.current = null; // Clear the WebSocket instance
     };
 
-    ws.onerror = (error) => {
+    wsRef.current.onerror = (error) => {
       console.error("WebSocket error:", error);
       wsRef.current = null; // Clear the WebSocket instance
     };
@@ -118,76 +61,168 @@ export default function Home() {
     };
   }, []); // Empty dependency array ensures this runs only once on mount
 
+  useEffect(() => {
+    if (wsRef.current) {
+      wsRef.current.onmessage = (event) => {
+        const message = JSON.parse(event.data);
+
+        if (message.historical) {
+          // Historical data
+          console.log("Historical Message Received");
+
+          setData((prevData) =>
+            prevData.map((data) => {
+              const channel = channels.find(
+                (channel) => channel.id === data.id
+              )!.channel;
+
+              if (channel.dbField === message.field) {
+                console.log("Widget has matching field");
+
+                const widgetData: DataPoint[] = message.data.map(
+                  (item: { timestamp: string; value: number }) => {
+                    return {
+                      timestamp: new Date(item.timestamp),
+                      value: item.value,
+                    };
+                  }
+                );
+
+                return {
+                  id: data.id,
+                  data: widgetData,
+                };
+              } else {
+                console.log(
+                  `Fields did not match ${channel.dbField} and ${message.field}`
+                );
+                return data;
+              }
+            })
+          );
+        } else {
+          // Live data
+
+          setData((prevData) =>
+            prevData.map((data) => {
+              const channel = channels.find(
+                (channel) => channel.id === data.id
+              )!.channel;
+
+              const field = channel.jsonField;
+              let newValue = null;
+              if (field in message) {
+                console.log("%s in message.", field);
+                newValue = message[field];
+              } else if (field in message.rockTelem) {
+                console.log("%s in message.rockTelem.", field);
+                newValue = message.rockTelem[field];
+              } else if (field in message.rockTelem.accelTelem) {
+                console.log("%s in message.rockTelem.accelTelem.", field);
+                newValue = message.rockTelem.accelTelem[field];
+              } else if (field in message.rockTelem.events) {
+                newValue = message.rockTelem.events[field];
+              } else if (field in message.rockTelem.gpsTelem) {
+                newValue = message.rockTelem.gpsTelem[field];
+              } else if (field in message.rockTelem.imuTelem) {
+                newValue = message.rockTelem.imuTelem[field];
+              } else if (field in message.rockTelem.metadata) {
+                newValue = message.rockTelem.metadata[field];
+              } else {
+                console.log("%s not in message.", field);
+              }
+
+              if (newValue) {
+                return {
+                  id: data.id,
+                  data: [
+                    ...data.data,
+                    { timestamp: new Date(), value: newValue },
+                  ],
+                };
+              }
+
+              return data;
+            })
+          );
+        }
+      };
+    }
+  }, [channels]);
+
   const onLayoutChange = (layout: Layout[]) => {
-    setWidgets((prevWidgets) =>
-      prevWidgets.map((widget) => {
-        const updatedLayout = layout.find((l) => l.i === widget.layout.i);
+    setLayouts((prevLayouts) =>
+      prevLayouts.map((prevLayout) => {
+        const updatedLayout = layout.find((l) => l.i === prevLayout.id);
         if (updatedLayout) {
-          return { ...widget, layout: updatedLayout };
+          return {
+            id: prevLayout.id,
+            layout: updatedLayout,
+          };
         }
-        return widget;
+        return prevLayout;
       })
     );
   };
 
-  const onWidgetModeChange = (widgetId: string, newMode: string) => {
-    setWidgets((prevWidgets) =>
-      prevWidgets.map((widget) => {
-        if (widget.layout.i === widgetId && newMode === "15m Chart") {
-          if (wsRef.current) {
-            wsRef.current.send(
-              JSON.stringify({
-                start: -15,
-                stop: 0,
-                field: widget.channel.dbField,
-              })
-            );
-          } else {
-            console.error(
-              "WebSocket not connected. Cannot request historical data."
-            );
-          }
-          return { ...widget, mode: newMode };
-        } else if (widget.layout.i === widgetId && newMode === "60m Chart") {
-          if (wsRef.current) {
-            wsRef.current.send(
-              JSON.stringify({
-                start: -60,
-                stop: 0,
-                field: widget.channel.dbField,
-              })
-            );
-          } else {
-            console.error(
-              "WebSocket not connected. Cannot request historical data."
-            );
-          }
-          return { ...widget, mode: newMode };
-        } else if (widget.layout.i === widgetId) {
-          return { ...widget, mode: newMode };
+  const children = useMemo(() => {
+    const onWidgetModeChange = (widgetId: string, newMode: string) => {
+      const channel = channels.find((channel) => channel.id === widgetId)!;
+      if (channel.id === widgetId && newMode === "15m Chart") {
+        if (wsRef.current) {
+          wsRef.current.send(
+            JSON.stringify({
+              start: -15,
+              stop: 0,
+              field: channel.channel.dbField,
+            })
+          );
+        } else {
+          console.error(
+            "WebSocket not connected. Cannot request historical data."
+          );
         }
+      } else if (channel.id === widgetId && newMode === "60m Chart") {
+        if (wsRef.current) {
+          wsRef.current.send(
+            JSON.stringify({
+              start: -60,
+              stop: 0,
+              field: channel.channel.dbField,
+            })
+          );
+        } else {
+          console.error(
+            "WebSocket not connected. Cannot request historical data."
+          );
+        }
+      }
+    };
 
-        return widget;
-      })
-    );
-  };
+    return channels.map((channel) => {
+      const deleteWidget = () => {
+        console.log("Deleting widget", channel.id);
+        setChannels((prevChannels) =>
+          prevChannels.filter((c) => c.id !== channel.id)
+        );
+        setLayouts((prevLayouts) =>
+          prevLayouts.filter((w) => w.layout.i !== channel.id)
+        );
+        setData((prevData) => prevData.filter((d) => d.id !== channel.id));
+      };
 
-  // TODO for performance improvement, find a way that widgets does not rely on layout (then we can memoize the children and avoid re-rendering)
-  const children = widgets.map((widget) => {
-    const deleteWidget = () =>
-      setWidgets((prevWidgets) =>
-        prevWidgets.filter((w) => w.layout.i !== widget.layout.i)
+      return (
+        <DashboardWidget
+          key={channel.id}
+          id={channel.id}
+          channel={channel.channel}
+          data={data.find((d) => d.id === channel.id)!.data}
+          deleteWidget={deleteWidget}
+          onModeChange={onWidgetModeChange}
+        />
       );
-
-    return (
-      <DashboardWidget
-        key={widget.layout.i}
-        widget={widget}
-        deleteWidget={deleteWidget}
-        onModeChange={onWidgetModeChange}
-      />
-    );
-  });
+    });
+  }, [channels, data]);
 
   return (
     <div>
@@ -195,7 +230,7 @@ export default function Home() {
         className="layout"
         draggableCancel=".drag-ignore"
         layouts={{
-          lg: widgets.map((widget) => widget.layout),
+          lg: layouts.map((layout) => layout.layout),
         }}
         cols={{ lg: 24, md: 20, sm: 14, xs: 10, xxs: 6 }}
         rowHeight={50}
@@ -206,8 +241,16 @@ export default function Home() {
         {children}
       </ResponsiveReactGridLayout>
       <div className="fixed bottom-10 right-10 z-50 flex gap-2">
-        <PresetSelector setWidgets={setWidgets} />
-        <TelemetryAdder setWidgets={setWidgets}></TelemetryAdder>
+        <PresetSelector
+          setChannels={setChannels}
+          setLayouts={setLayouts}
+          setData={setData}
+        />
+        <TelemetryAdder
+          setChannels={setChannels}
+          setLayouts={setLayouts}
+          setData={setData}
+        />
       </div>
     </div>
   );

--- a/ground-server/src/components/dashboard/dashboard-widget.tsx
+++ b/ground-server/src/components/dashboard/dashboard-widget.tsx
@@ -20,10 +20,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 import { cn } from "@/lib/utils";
-import { type Widget } from "@/lib/definitions";
+import { type TelemetryChannel, type DataPoint } from "@/lib/definitions";
 
 interface DashboardWidgetProps {
-  widget: Widget;
+  id: string;
+  channel: TelemetryChannel;
+  data: DataPoint[];
   deleteWidget: () => void;
   style?: CSSProperties;
   className?: string;
@@ -37,7 +39,9 @@ interface DashboardWidgetProps {
 export const DashboardWidget = forwardRef<HTMLDivElement, DashboardWidgetProps>(
   (
     {
-      widget,
+      id,
+      channel,
+      data,
       deleteWidget,
       style,
       className,
@@ -49,14 +53,14 @@ export const DashboardWidget = forwardRef<HTMLDivElement, DashboardWidgetProps>(
     },
     ref
   ) => {
-    const WidgetComponent = widget.channel.component;
+    const WidgetComponent = channel.component;
 
-    const [mode, setMode] = useState(widget.channel.modes[0] ?? "");
+    const [mode, setMode] = useState(channel.modes[0] ?? "");
 
     const handleModeChange = (newMode: string) => {
       setMode(newMode);
-      onModeChange(widget.layout.i, newMode);
-    }
+      onModeChange(id, newMode);
+    };
 
     return (
       <div
@@ -67,21 +71,24 @@ export const DashboardWidget = forwardRef<HTMLDivElement, DashboardWidgetProps>(
         onMouseUp={onMouseUp}
         onTouchEnd={onTouchEnd}
       >
-        <WidgetComponent mode={mode} channel={widget.channel} data={widget.data} />
+        <WidgetComponent mode={mode} channel={channel} data={data} />
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <DotsVerticalIcon className="drag-ignore absolute top-2 right-1 h-4 cursor-pointer" />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-34 drag-ignore">
-            <DropdownMenuRadioGroup value={mode} onValueChange={handleModeChange}>
-              {widget.channel.modes.map((m) => (
+            <DropdownMenuRadioGroup
+              value={mode}
+              onValueChange={handleModeChange}
+            >
+              {channel.modes.map((m) => (
                 <DropdownMenuRadioItem key={m} value={m}>
                   {m}
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>
-            {widget.channel.modes.length > 0 && <DropdownMenuSeparator />}
+            {channel.modes.length > 0 && <DropdownMenuSeparator />}
             <DropdownMenuItem
               inset
               className="text-red-600"

--- a/ground-server/src/components/dashboard/preset-selector.tsx
+++ b/ground-server/src/components/dashboard/preset-selector.tsx
@@ -26,13 +26,25 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { type Preset, type Widget } from "@/lib/definitions";
 import { PRESETS } from "@/lib/dashboard-presets";
 
+import {
+  type DataPoint,
+  type TelemetryChannel,
+  type Preset,
+} from "@/lib/definitions";
+import { type Layout } from "react-grid-layout";
+
 export function PresetSelector({
-  setWidgets,
+  setChannels,
+  setLayouts,
+  setData,
 }: {
-  setWidgets: Dispatch<SetStateAction<Widget[]>>;
+  setChannels: Dispatch<
+    SetStateAction<{ id: string; channel: TelemetryChannel }[]>
+  >;
+  setLayouts: Dispatch<SetStateAction<{ id: string; layout: Layout }[]>>;
+  setData: Dispatch<SetStateAction<{ id: string; data: DataPoint[] }[]>>;
 }) {
   const [open, setOpen] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
@@ -46,7 +58,12 @@ export function PresetSelector({
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[200px] p-0" align="end">
-          <PresetList setOpen={setOpen} setWidgets={setWidgets} />
+          <PresetList
+            setOpen={setOpen}
+            setChannels={setChannels}
+            setLayouts={setLayouts}
+            setData={setData}
+          />
         </PopoverContent>
       </Popover>
     );
@@ -67,7 +84,12 @@ export function PresetSelector({
           </DrawerDescription>
         </DrawerHeader>
         <div className="border-t">
-          <PresetList setOpen={setOpen} setWidgets={setWidgets} />
+          <PresetList
+            setOpen={setOpen}
+            setChannels={setChannels}
+            setLayouts={setLayouts}
+            setData={setData}
+          />
         </div>
       </DrawerContent>
     </Drawer>
@@ -76,14 +98,22 @@ export function PresetSelector({
 
 function PresetList({
   setOpen,
-  setWidgets,
+  setChannels,
+  setLayouts,
+  setData,
 }: {
   setOpen: (open: boolean) => void;
-  setWidgets: Dispatch<SetStateAction<Widget[]>>;
+  setChannels: Dispatch<
+    SetStateAction<{ id: string; channel: TelemetryChannel }[]>
+  >;
+  setLayouts: Dispatch<SetStateAction<{ id: string; layout: Layout }[]>>;
+  setData: Dispatch<SetStateAction<{ id: string; data: DataPoint[] }[]>>;
 }) {
   const selectPreset = (preset: Preset) => {
     console.log("Selected preset:", preset);
-    setWidgets([]);
+    setChannels([]);
+    setLayouts([]);
+    setData([]);
     setOpen(false);
   };
 

--- a/ground-server/src/components/dashboard/telemetry-adder.tsx
+++ b/ground-server/src/components/dashboard/telemetry-adder.tsx
@@ -26,13 +26,19 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { type TelemetryChannel, type Widget } from "@/lib/definitions";
 import { TELEMETRY_CHANNELS } from "@/lib/telemetry-channels";
 
+import { type DataPoint, type TelemetryChannel } from "@/lib/definitions";
+import { type Layout } from "react-grid-layout";
+
 export function TelemetryAdder({
-  setWidgets,
+  setChannels,
+  setLayouts,
+  setData
 }: {
-  setWidgets: Dispatch<SetStateAction<Widget[]>>;
+  setChannels: Dispatch<SetStateAction<{ id: string; channel: TelemetryChannel }[]>>;
+  setLayouts: Dispatch<SetStateAction<{ id: string; layout: Layout }[]>>;
+  setData: Dispatch<SetStateAction<{ id: string; data: DataPoint[] }[]>>;
 }) {
   const [open, setOpen] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
@@ -46,7 +52,7 @@ export function TelemetryAdder({
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[200px] p-0" align="end">
-          <TelemetryChannelList setOpen={setOpen} setWidgets={setWidgets} />
+          <TelemetryChannelList setOpen={setOpen} setChannels={setChannels} setLayouts={setLayouts} setData={setData} />
         </PopoverContent>
       </Popover>
     );
@@ -67,7 +73,7 @@ export function TelemetryAdder({
           </DrawerDescription>
         </DrawerHeader>
         <div className="border-t">
-          <TelemetryChannelList setOpen={setOpen} setWidgets={setWidgets} />
+          <TelemetryChannelList setOpen={setOpen} setChannels={setChannels} setLayouts={setLayouts} setData={setData} />
         </div>
       </DrawerContent>
     </Drawer>
@@ -76,30 +82,36 @@ export function TelemetryAdder({
 
 function TelemetryChannelList({
   setOpen,
-  setWidgets,
+  setChannels,
+  setLayouts,
+  setData
 }: {
   setOpen: (open: boolean) => void;
-  setWidgets: Dispatch<SetStateAction<Widget[]>>;
+  setChannels: Dispatch<SetStateAction<{ id: string; channel: TelemetryChannel }[]>>;
+  setLayouts: Dispatch<SetStateAction<{ id: string; layout: Layout }[]>>;
+  setData: Dispatch<SetStateAction<{ id: string; data: DataPoint[] }[]>>;
 }) {
   const addWidget = (channel: TelemetryChannel) => {
     const id = Date.now().toString();
     console.log(`Adding widget with id: ${id}`);
-    const newWidget = {
-      channel: channel,
-      layout: {
-        i: id,
-        x: 0,
-        y: 0,
-        w: 3,
-        h: 3,
-        minW: 3,
-        minH: 3,
+    
+    setChannels((prevChannels) => [...prevChannels, { id, channel }]);
+    setLayouts((prevLayouts) => [
+      ...prevLayouts,
+      {
+        id: id,
+        layout: {
+          i: id,
+          x: 0,
+          y: 0,
+          w: 3,
+          h: 3,
+          minW: 3,
+          minH: 3,
+        },
       },
-      id: id,
-      data: [],
-    };
-
-    setWidgets((prevWidgets) => [...prevWidgets, newWidget]);
+    ]);
+    setData((prevData) => [...prevData, { id, data: [] }]);
     setOpen(false);
   };
 

--- a/ground-server/src/lib/definitions.ts
+++ b/ground-server/src/lib/definitions.ts
@@ -1,5 +1,4 @@
 import { type ComponentType } from "react";
-import { type Layout } from "react-grid-layout";
 
 export type DataPoint = {
   timestamp: Date;
@@ -20,13 +19,6 @@ export type TelemetryChannel = {
   jsonField: string;
   modes: string[];
   component: ComponentType<WidgetProps>;
-};
-
-export type Widget = {
-  channel: TelemetryChannel;
-  layout: Layout;
-  id: string;
-  data: DataPoint[];
 };
 
 export type Preset = {


### PR DESCRIPTION
### TL;DR

Refactored dashboard state management to separate widget data, layouts, and channels into distinct state arrays.

### What changed?

- Split the monolithic `widgets` state into three separate states:
  - `channels`: Stores telemetry channel configurations
  - `layouts`: Manages grid layout information
  - `data`: Handles telemetry data points
- Updated WebSocket message handling to work with the new state structure
- Modified widget components to receive individual props instead of a combined widget object
- Implemented `useMemo` for widget rendering optimization
- Updated preset selector and telemetry adder components to work with the new state management approach

### How to test?

1. Launch the ground server application
2. Add new telemetry widgets using the telemetry adder
3. Verify that widgets receive and display data correctly
4. Test widget repositioning and resizing
5. Confirm that historical data loading works for 15m and 60m chart modes
6. Verify that widget deletion functions properly

### Why make this change?

This restructuring improves performance by:
- Reducing unnecessary re-renders through state separation
- Enabling better memoization of widget components
- Making the state structure more maintainable and easier to debug
- Allowing for more granular updates to specific aspects of widgets