### PR TITLE
Store layout in localStorage

### DIFF
--- a/ground-server/src/components/dashboard/telemetry-adder.tsx
+++ b/ground-server/src/components/dashboard/telemetry-adder.tsx
@@ -99,7 +99,7 @@ function TelemetryChannelList({
     setLayouts((prevLayouts) => [
       ...prevLayouts,
       {
-        id: id,
+        id,
         layout: {
           i: id,
           x: 0,

--- a/ground-server/src/lib/definitions.ts
+++ b/ground-server/src/lib/definitions.ts
@@ -12,6 +12,7 @@ export type WidgetProps = {
 };
 
 export type TelemetryChannel = {
+  id: string;
   label: string;
   unit?: string;
   requiresAuth: boolean;

--- a/ground-server/src/lib/telemetry-channels.ts
+++ b/ground-server/src/lib/telemetry-channels.ts
@@ -4,6 +4,7 @@ import type { TelemetryChannel } from "@/lib/definitions";
 
 export const TELEMETRY_CHANNELS: TelemetryChannel[] = [
   {
+    id: "sv1_cont",
     label: "Solenoid Valve 1 Continuity",
     requiresAuth: false,
     dbField: "sv1_cont",


### PR DESCRIPTION
### TL;DR
Added persistence to dashboard layouts and channels using localStorage

### What changed?
- Implemented localStorage to save and restore dashboard layouts and channel configurations
- Added loading of stored layouts and channels on component mount
- Updated layout change handler to persist changes to localStorage
- Added ID field to telemetry channel type definition
- Added ID to solenoid valve telemetry channel

### How to test?
1. Add widgets to the dashboard
2. Arrange widgets in a specific layout
3. Refresh the page
4. Verify that widgets and their layouts are restored to their previous state
5. Move widgets around and refresh again to ensure new layouts are saved

### Why make this change?
Users need their dashboard configurations to persist between sessions to avoid having to recreate their preferred layouts each time they access the ground server interface. This enhancement improves user experience by maintaining dashboard state across page reloads and browser sessions.