### PR TITLE
Implement SV1

### DIFF
--- a/.github/workflows/fill_station_action.yml
+++ b/.github/workflows/fill_station_action.yml
@@ -46,6 +46,7 @@ jobs:
             bazel build //fill:all
             ./fill/test/bv_test.sh
             ./fill/test/qd_test.sh
+            ./fill/test/sv1_test.sh
           elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
             sudo apt-get install g++-11-arm-linux-gnueabihf
             sudo apt install gcc-11-arm-linux-gnueabihf

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ bazel_wrapper.bazelrc
 # Go artifacts
 go-proxies/fill-telem-proxy/main
 go-proxies/websocket-proxy/main
+
+# Test Output
+fill_station_output.txt

--- a/fill/BUILD
+++ b/fill/BUILD
@@ -5,6 +5,7 @@ cc_binary(
         "//protos:command_cc_grpc",
         "//fill/actuators:qd",
         "//fill/actuators:ball_valve",
+        "//fill/actuators:sol_valve",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@abseil-cpp//absl/strings:str_format",

--- a/fill/actuators/BUILD
+++ b/fill/actuators/BUILD
@@ -33,7 +33,9 @@ cc_library(
     name = "sol_valve",
     srcs = ["sol_valve.cc"],
     hdrs = ["sol_valve.h"],
-    deps = [":actuator"],
+    deps = ["//fill/lib/MockWiringPi:mock_wiringpi"],
+    includes = ["."],
+    linkopts = ["-lwiringPi"],
     visibility = [
         "//fill:__subpackages__",
         ],

--- a/fill/actuators/sol_valve.cc
+++ b/fill/actuators/sol_valve.cc
@@ -1,0 +1,39 @@
+#include "sol_valve.h"
+
+SolValve::SolValve(){
+    wiringPiSetupGpio();
+    pinMode(SV_SIGNAL, OUTPUT);
+
+    // starting state set to low 
+    digitalWrite(SV_SIGNAL, LOW);
+    isOpen=false;
+}
+
+SolValve::~SolValve(){}
+
+
+
+void SolValve::open(){
+    pinMode(SV_SIGNAL, OUTPUT);
+    digitalWrite(SV_SIGNAL, HIGH);
+    delay(150);
+    pinMode(SV_SIGNAL, PWM_OUTPUT);
+    pwmWrite(SV_SIGNAL, 430); 
+}
+void SolValve::openAsync(){
+    if (isOpen){
+     return; // cannot actuate a sensor that is already actuating 
+    }
+
+    std::thread open_thread(&SolValve::open, this);
+    open_thread.detach(); // we want to continue normal operation 
+
+    return;
+}
+void SolValve::close(){
+    pinMode(SV_SIGNAL, OUTPUT);
+    digitalWrite(SV_SIGNAL, LOW);
+    isOpen=false;
+}
+
+

--- a/fill/actuators/sol_valve.h
+++ b/fill/actuators/sol_valve.h
@@ -1,0 +1,24 @@
+#ifndef SOL_VALVE_H
+#define SOL_VALVE_H
+
+#define SV_SIGNAL 13
+
+#include <thread>
+#include "wiringPi.h"
+
+
+class SolValve {
+    private:
+        bool isOpen; 
+        void open();
+        
+    public: 
+        SolValve();
+        ~SolValve();
+        
+
+        void openAsync();
+        void close();
+};
+
+#endif

--- a/fill/fill_station.cc
+++ b/fill/fill_station.cc
@@ -9,6 +9,7 @@
 
 #include "actuators/qd.h"
 #include "actuators/ball_valve.h"
+#include "actuators/sol_valve.h"
 
 #include "wiringPi.h"
 
@@ -40,6 +41,7 @@ using grpc::Status;
 /* Actuators */
 QD qd; 
 BallValve ball_valve;
+SolValve sv1;
 
 ABSL_FLAG(uint16_t, server_port, 50051, "Server port for the service");
 
@@ -90,7 +92,13 @@ class CommanderServiceImpl final : public Commander::Service
                 ball_valve.powerOn();
             }
         }
-
+        if(request->has_sv1_open()){
+            if(request->sv1_open()){
+                sv1.openAsync();
+            } else{
+                sv1.close();
+            }
+        }
         if (request->sv2_close()){
             // send TCP command to rocket_controller 
         }

--- a/fill/lib/MockWiringPi/wiringPi.c
+++ b/fill/lib/MockWiringPi/wiringPi.c
@@ -35,6 +35,10 @@ int digitalRead(int pin) {
     return 0;
 }
 
+void pwmWrite(int pin, int value) {
+    printf("[MOCK] pwmWrite called, pin: %d and value: %d\n", pin, value);
+}
+
 void pullUpDnControl(int pin, int pud) {
     printf("[MOCK] pullUpDnControl called, pin: %d, pud: %d\n", pin, pud);
 }

--- a/fill/test/qd_test_expected_output.txt
+++ b/fill/test/qd_test_expected_output.txt
@@ -8,6 +8,9 @@
 [MOCK] pinMode called, pin: 23, mode: 1
 [MOCK] digitalWrite called, pin: 24, value: 0
 [MOCK] digitalWrite called, pin: 23, value: 0
+[MOCK] wiringPiSetupGpio called
+[MOCK] pinMode called, pin: 13, mode: 1
+[MOCK] digitalWrite called, pin: 13, value: 0
 Server listening on 0.0.0.0:50051
 [MOCK] digitalWrite called, pin: 5, value: 0
 [MOCK] digitalWrite called, pin: 22, value: 1

--- a/fill/test/sv1_test.sh
+++ b/fill/test/sv1_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Check if grpcurl is already installed
+if ! command -v grpcurl &> /dev/null; then
+  echo "Installing grpcurl..."
+  wget https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_amd64.deb
+  sudo apt install ./grpcurl_1.9.1_linux_amd64.deb
+  rm ./grpcurl_1.9.1_linux_amd64.deb # Clean up the downloaded deb file
+  echo "grpcurl installed."
+fi
+
+# Capture output and check against expected value
+# Run fill_station in the background and capture its PID
+stdbuf -oL ./bazel-bin/fill/fill_station > fill_station_output.txt 2>&1 &
+fill_station_pid=$!
+
+# Wait for fill_station to start listening
+while [[ ! $(grep "Server listening on" fill_station_output.txt) ]]; do
+  sleep 0.1 # Check every 0.1 seconds
+  if [[ $(ps -p $fill_station_pid) == "" ]]; then
+      echo "fill_station died unexpectedly"
+      exit 1
+  fi
+done
+
+# Send grpcurl command
+grpcurl -plaintext -d '{"sv1_open": true}' localhost:50051 command.Commander/SendCommand
+sleep 1
+grpcurl -plaintext -d '{"sv1_open": false}' localhost:50051 command.Commander/SendCommand
+
+# Kill fill_station after a timeout (adjust timeout as needed)
+sleep 2
+pkill -9 -f fill_station
+
+actual_output=$(cat fill_station_output.txt)
+expected_output=$(cat ./fill/test/sv1_test_expected_output.txt)
+if [[ "$actual_output" != "$expected_output" ]]; then
+    echo "Output mismatch:"
+    echo "Expected:"
+    echo "$expected_output"
+    echo "Actual:"
+    echo "$actual_output"
+    exit 1
+fi

--- a/fill/test/sv1_test_expected_output.txt
+++ b/fill/test/sv1_test_expected_output.txt
@@ -12,7 +12,10 @@
 [MOCK] pinMode called, pin: 13, mode: 1
 [MOCK] digitalWrite called, pin: 13, value: 0
 Server listening on 0.0.0.0:50051
-[MOCK] digitalWrite called, pin: 23, value: 1
-[MOCK] digitalWrite called, pin: 23, value: 0
-[MOCK] digitalWrite called, pin: 24, value: 1
-[MOCK] digitalWrite called, pin: 24, value: 0
+[MOCK] pinMode called, pin: 13, mode: 1
+[MOCK] digitalWrite called, pin: 13, value: 1
+[MOCK] delay called, howLong: 150 (usleep used in mock)
+[MOCK] pinMode called, pin: 13, mode: 2
+[MOCK] pwmWrite called, pin: 13 and value: 430
+[MOCK] pinMode called, pin: 13, mode: 1
+[MOCK] digitalWrite called, pin: 13, value: 0


### PR DESCRIPTION
### TL;DR
Added solenoid valve control functionality to the fill station system.

### What changed?
- Implemented solenoid valve (SV1) control with PWM support
- Created new solenoid valve class with open, openAsync, and close methods
- Added GPIO pin 13 configuration for SV1 control
- Integrated SV1 commands into the gRPC command service
- Added mock PWM functionality to the WiringPi testing framework

### How to test?
1. Run the fill station service
2. Use grpcurl to send commands:
   ```bash
   grpcurl -plaintext -d '{"sv1_open": true}' localhost:50051 command.Commander/SendCommand
   grpcurl -plaintext -d '{"sv1_open": false}' localhost:50051 command.Commander/SendCommand
   ```
3. Execute the automated test script:
   ```bash
   ./fill/test/sv1_test.sh
   ```

### Why make this change?
To enable precise control of the solenoid valve in the fill station system, allowing for automated valve operations with PWM support for maintaining valve positions.