### PR TITLE
Add timeout to grpc calls so fill station reconnects

### DIFF
--- a/go-proxies/fill-telem-proxy/main.go
+++ b/go-proxies/fill-telem-proxy/main.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/cornellrocketryteam/Ground-Software/go-proxies/proto-out"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 func main() {
@@ -26,7 +27,15 @@ func main() {
 
 	// Set up a connection to the grpc server
 	address := os.Getenv("FILL_HOSTNAME") + ":50051"
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+			Timeout:             2 * time.Second,  // wait 2 seconds for ping ack before considering the connection dead
+			PermitWithoutStream: true,
+		}),
+	)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/go-proxies/rocket-telem-proxy/main.go
+++ b/go-proxies/rocket-telem-proxy/main.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/cornellrocketryteam/Ground-Software/go-proxies/proto-out"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 func main() {
@@ -26,7 +27,15 @@ func main() {
 
 	// Set up a connection to the grpc server
 	address := os.Getenv("FILL_HOSTNAME") + ":50051"
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+			Timeout:             2 * time.Second,  // wait 2 seconds for ping ack before considering the connection dead
+			PermitWithoutStream: true,
+		}),
+	)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}


### PR DESCRIPTION
### TL;DR
Added gRPC keepalive parameters to telemetry proxy connections

### What changed?
Added keepalive configuration to gRPC client connections in both fill and rocket telemetry proxies. The parameters include:
- 10-second ping interval during inactivity
- 2-second timeout for ping acknowledgment
- Enabled permit without stream

### How to test?
1. Run the telemetry proxies
2. Leave the connection idle for >10 seconds
3. Verify the connection remains active
4. Simulate network interruption and confirm connection is marked as dead after 2 seconds

### Why make this change?
To improve connection reliability by detecting and handling disconnections more quickly. This prevents scenarios where the application thinks it's connected but the underlying connection is actually dead, ensuring more robust telemetry data transmission.